### PR TITLE
Release management fix up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lator"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "lator"
-version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/cd/build-and-upload.sh
+++ b/cd/build-and-upload.sh
@@ -3,9 +3,7 @@
 # This script can be used to build a release version of the application and upload it as an asset of a Github release.
 #
 # Usage:
-#   build-and-upload.sh <version> <target>
-#
-# <target> must be either "linux" or "windows"
+#   build-and-upload.sh <version>
 #
 # Requirements:
 # - The GITHUB_TOKEN environment variable needs to be set.


### PR DESCRIPTION
# Context

This PR fixes a couple of issues stemming from #1.

### Project version

Currently, this version needs to be manually defined in two different locations:

- The name of a Github release
- The `version` property of Cargo.toml.
  
This could lead to issues such as having a single commit with two different version numbers.

### CD script documentation

A shell script used in the Continuous Deployment workflow documents invalid script parameters.

# Changes

1. Remove the `version` definition from `Cargo.toml`.\
    As I am not planning on releasing this project to crates.io in the short term, this project property is not required.\
    It also saves me from having to synchronize the version declared in this file with the release name on Github.
3. Fix *usage* comment at the beginning of `build-and-upload.sh`.
    

:bulb: If I ever need to re-introduce the `version` Cargo property, a better way to manage release management would be for Github Actions to automatically create the release based on this property's value.