### PR TITLE
Support multiplication operation

### DIFF
--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -30,34 +30,46 @@ impl OperatorType {
 mod tests {
     use rstest::rstest;
 
-    use super::*;
+    use crate::engine::ast::test_helpers::{add_node, num_node};
 
     #[rstest]
     #[case("0")]
     #[case("123")]
     #[case("123.456")]
     fn should_parse_str_into_number(#[case] num_repr: &str) {
-        let num_node = number(num_repr);
+        let num_node = num_node(num_repr);
         assert_eq!(num_node.resolve().to_string(), num_repr);
     }
 
     #[test]
     fn should_add_leading_zero_when_number_starts_with_dot() {
-        let num_node = number(".456");
+        let num_node = num_node(".456");
         assert_eq!(num_node.resolve().to_string(), "0.456");
     }
 
     #[test]
     fn should_add_numbers() {
-        let add = Ast::Operator(
-            OperatorType::Addition,
-            number(".456").into(),
-            number("18.1").into(),
-        );
+        let add = add_node(num_node(".456"), num_node("18.1"));
         assert_eq!(add.resolve().to_string(), "18.556");
     }
+}
 
-    fn number(repr: &str) -> Ast {
-        Ast::Number(Number::from_str(repr).unwrap())
+/// This module provides helper functions to create ASTs with at little noise as possible.
+#[cfg(test)]
+pub mod test_helpers {
+    use crate::engine::ast::Ast;
+    use crate::engine::number::Number;
+    use crate::engine::operator::OperatorType;
+
+    pub fn num_node(value: &str) -> Ast {
+        Ast::Number(Number::from_str(value).unwrap())
+    }
+
+    pub fn mul_node(lhs: Ast, rhs: Ast) -> Ast {
+        Ast::Operator(OperatorType::Multiplication, Box::new(lhs), Box::new(rhs))
+    }
+
+    pub fn add_node(lhs: Ast, rhs: Ast) -> Ast {
+        Ast::Operator(OperatorType::Addition, Box::new(lhs), Box::new(rhs))
     }
 }

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -21,6 +21,7 @@ impl OperatorType {
         match self {
             OperatorType::Addition => lhs + rhs,
             OperatorType::Subtraction => lhs - rhs,
+            OperatorType::Multiplication => lhs * rhs,
         }
     }
 }

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -1,6 +1,16 @@
 use crate::engine::number::Number;
 use crate::engine::operator::OperatorType;
 
+/// An AST (Abstract Syntax Tree) represents a mathematical expression in the form of a tree.
+///
+/// For example, the expression 1+2*3 is represented as:
+/// ```text
+///    +
+///  /   \
+/// 1     *
+///     /   \
+///    2     3
+/// ```
 #[derive(Debug, PartialEq)]
 pub enum Ast {
     Number(Number),

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -34,6 +34,16 @@ impl OperatorType {
             OperatorType::Multiplication => lhs * rhs,
         }
     }
+
+    /// Indicates the priority of an operator.\
+    /// A higher value means a higher priority.
+    pub fn priority(&self) -> usize {
+        match self {
+            OperatorType::Addition => 0,
+            OperatorType::Subtraction => 0,
+            OperatorType::Multiplication => 1,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -60,6 +60,7 @@ mod tests {
     #[case("18+1.48", "19.48")]
     #[case(" 1+\t2+    3+4 ", "10")]
     #[case("1+2-4", "-1")]
+    #[case("1+2×4", "9")]
     fn test_should_evaluate_valid_expressions(#[case] num_repr: &str, #[case] result: &str) {
         assert_eq!(evaluate(num_repr), Ok(result.into()));
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -61,6 +61,8 @@ mod tests {
     #[case(" 1+\t2+    3+4 ", "10")]
     #[case("1+2-4", "-1")]
     #[case("1+2×4", "9")]
+    #[case("13×24-54-52-45×37×90+63", "-149581")]
+    #[case("91×59×41×88×21+69+67×8", "406798997")]
     fn test_should_evaluate_valid_expressions(#[case] num_repr: &str, #[case] result: &str) {
         assert_eq!(evaluate(num_repr), Ok(result.into()));
     }

--- a/src/engine/number.rs
+++ b/src/engine/number.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 use std::num::ParseFloatError;
-use std::ops::{Add, Sub};
+use std::ops::{Add, Mul, Sub};
 
 use crate::engine::Error;
 
@@ -45,6 +45,16 @@ impl Sub for Number {
     }
 }
 
+impl Mul for Number {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Number {
+            value: self.value * rhs.value,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::engine::number::Number;
@@ -67,5 +77,12 @@ mod tests {
         let lhs = Number::from_str("3.5").unwrap();
         let rhs = Number::from_str("1").unwrap();
         assert_eq!("2.5", (lhs - rhs).to_string());
+    }
+
+    #[test]
+    fn test_mul_number() {
+        let lhs = Number::from_str("3.5").unwrap();
+        let rhs = Number::from_str("3").unwrap();
+        assert_eq!("10.5", (lhs * rhs).to_string());
     }
 }

--- a/src/engine/operator.rs
+++ b/src/engine/operator.rs
@@ -2,4 +2,5 @@
 pub enum OperatorType {
     Addition,
     Subtraction,
+    Multiplication,
 }

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -71,8 +71,7 @@ impl ParsingContext {
 
 #[cfg(test)]
 mod tests {
-    use crate::engine::ast::Ast;
-    use crate::engine::number::Number;
+    use crate::engine::ast::test_helpers::*;
     use crate::engine::operator::OperatorType;
     use crate::engine::parser::parse;
     use crate::engine::token::{Token, TokenType};
@@ -84,7 +83,7 @@ mod tests {
     fn test_parsing_one_number_token_should_produce_number_node() {
         let token = Token::new(TokenType::Number, "49", 0);
         let result = parse(&[token]).unwrap();
-        assert_eq!(number_node("49"), result);
+        assert_eq!(num_node("49"), result);
     }
 
     #[test]
@@ -95,11 +94,7 @@ mod tests {
             Token::new(TokenType::Number, "1.5", 3),
         ];
 
-        let expected_tree = Ast::Operator(
-            OperatorType::Addition,
-            number_node("49").into(),
-            number_node("1.5").into(),
-        );
+        let expected_tree = add_node(num_node("49"), num_node("1.5"));
         assert_eq!(expected_tree, parse(&tokens).unwrap());
     }
 
@@ -153,9 +148,5 @@ mod tests {
             Token::new(ADD_TOKEN_TYPE, "+", 1),
         ];
         assert_eq!(Err(Error::InvalidExpression(1)), parse(&seq));
-    }
-
-    fn number_node(value: &str) -> Ast {
-        Ast::Number(Number::from_str(value).unwrap())
     }
 }

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -87,6 +87,10 @@ lazy_static! {
             TokenType::Operator(OperatorType::Subtraction),
             Regex::new(r"-").unwrap()
         ),
+        (
+            TokenType::Operator(OperatorType::Multiplication),
+            Regex::new(r"×").unwrap()
+        ),
     ]);
 }
 
@@ -179,6 +183,7 @@ mod tests {
     #[rstest]
     #[case("+", OperatorType::Addition)]
     #[case("-", OperatorType::Subtraction)]
+    #[case("×", OperatorType::Multiplication)]
     fn should_evaluate_operator_as_valid_token(#[case] expr: &str, #[case] op_type: OperatorType) {
         assert_eq!(
             vec![str_to_token(expr, TokenType::Operator(op_type))],

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -142,6 +142,7 @@ fn build_token_matching_pattern<'a>(
 
 #[cfg(test)]
 mod tests {
+    use crate::engine::token::test_helpers::{add_token, invalid_token, num_token};
     use rstest::rstest;
 
     use super::*;
@@ -172,10 +173,7 @@ mod tests {
     fn should_evaluate_number_with_two_decimal_separators_as_two_tokens() {
         let expr = "123.45.67";
         assert_eq!(
-            vec![
-                Token::new(TokenType::Number, "123.45", 0),
-                Token::new(TokenType::Number, ".67", 6)
-            ],
+            vec![num_token("123.45", 0), num_token(".67", 6)],
             tokenize(expr)
         );
     }
@@ -192,12 +190,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("123abc", vec![Token::new(TokenType::Number, "123", 0), Token::new(TokenType::Invalid, "abc", 3)])]
-    #[case("abc123", vec![Token::new(TokenType::Invalid, "abc", 0), Token::new(TokenType::Number, "123", 3)])]
-    #[case("123+.456", vec![Token::new(TokenType::Number, "123", 0),
-                            Token::new(TokenType::Operator(OperatorType::Addition), "+" , 3),
-                            Token::new(TokenType::Number, ".456", 4)
-    ])]
+    #[case("123abc", vec![num_token("123", 0), invalid_token("abc", 3)])]
+    #[case("abc123", vec![invalid_token("abc", 0), num_token("123", 3)])]
+    #[case("123+.456", vec![num_token("123", 0), add_token(3), num_token(".456", 4)])]
     fn should_evaluate_expression_as_sequence(#[case] expr: &str, #[case] tokens: Vec<Token>) {
         assert_eq!(tokens, tokenize(expr));
     }
@@ -205,15 +200,31 @@ mod tests {
     #[test]
     fn should_ignore_white_spaces() {
         let expr = " 1   + \t\t\t   \x0a2 ";
-        let expected_sequence = vec![
-            Token::new(TokenType::Number, "1", 1),
-            Token::new(TokenType::Operator(OperatorType::Addition), "+", 5),
-            Token::new(TokenType::Number, "2", 14),
-        ];
+        let expected_sequence = vec![num_token("1", 1), add_token(5), num_token("2", 14)];
         assert_eq!(expected_sequence, tokenize(expr));
     }
 
     fn str_to_token(expr: &str, token_type: TokenType) -> Token {
         Token::new(token_type, expr, 0)
+    }
+}
+
+#[cfg(test)]
+pub mod test_helpers {
+    use crate::engine::operator::OperatorType;
+    use crate::engine::token::{Token, TokenType};
+
+    const ADD_CHAR: &'static str = "+";
+
+    pub fn invalid_token(content: &str, start: usize) -> Token {
+        Token::new(TokenType::Invalid, content, start)
+    }
+
+    pub fn num_token(content: &str, start: usize) -> Token {
+        Token::new(TokenType::Number, content, start)
+    }
+
+    pub fn add_token(start: usize) -> Token<'static> {
+        Token::new(TokenType::Operator(OperatorType::Addition), ADD_CHAR, start)
     }
 }


### PR DESCRIPTION
# Context

This pull request adds support for the multiplication operation.

# Changes

- When a user presses the `*` key, or pastes an expression containing the `*` character, this character is replaced by `×`.
- The `×` character is interpreted as a multiplication operator.
- The parser builds an AST which prioritizes the evaluation of multiplication operators over other operators.
