### PR TITLE
Support signed numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+todo.md

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -105,6 +105,10 @@ pub mod test_helpers {
         Ast::Operator(OperatorType::Addition, Box::new(lhs), Box::new(rhs))
     }
 
+    pub fn sub_node(lhs: Ast, rhs: Ast) -> Ast {
+        Ast::Operator(OperatorType::Subtraction, Box::new(lhs), Box::new(rhs))
+    }
+
     pub fn neg_node(value: Ast) -> Ast {
         Ast::Negative(Box::new(value))
     }

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -13,8 +13,13 @@ use crate::engine::operator::OperatorType;
 /// ```
 #[derive(Debug, PartialEq)]
 pub enum Ast {
+    /// An actual, raw number.
+    /// Leaf nodes in AST are always [Ast::Number] nodes.
     Number(Number),
+    /// Applies the operator described by [OperatorType] using two sub-ASTs.
     Operator(OperatorType, Box<Ast>, Box<Ast>),
+    /// Applies the opposite function to value computed from the child AST.
+    Negative(Box<Ast>),
 }
 
 impl Ast {
@@ -22,6 +27,7 @@ impl Ast {
         match self {
             Ast::Number(num) => *num,
             Ast::Operator(op, lhs, rhs) => op.calculate(lhs.resolve(), rhs.resolve()),
+            Ast::Negative(value) => -value.resolve(),
         }
     }
 }
@@ -50,7 +56,7 @@ impl OperatorType {
 mod tests {
     use rstest::rstest;
 
-    use crate::engine::ast::test_helpers::{add_node, num_node};
+    use crate::engine::ast::test_helpers::{add_node, neg_node, num_node};
 
     #[rstest]
     #[case("0")]
@@ -72,9 +78,15 @@ mod tests {
         let add = add_node(num_node(".456"), num_node("18.1"));
         assert_eq!(add.resolve().to_string(), "18.556");
     }
+
+    #[test]
+    fn should_negate_number() {
+        let ast = neg_node(num_node("10"));
+        assert_eq!(ast.resolve().to_string(), "-10")
+    }
 }
 
-/// This module provides helper functions to create ASTs with at little noise as possible.
+/// This module provides helper functions to create ASTs with as little noise as possible.
 #[cfg(test)]
 pub mod test_helpers {
     use crate::engine::ast::Ast;
@@ -91,5 +103,9 @@ pub mod test_helpers {
 
     pub fn add_node(lhs: Ast, rhs: Ast) -> Ast {
         Ast::Operator(OperatorType::Addition, Box::new(lhs), Box::new(rhs))
+    }
+
+    pub fn neg_node(value: Ast) -> Ast {
+        Ast::Negative(Box::new(value))
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -54,6 +54,12 @@ mod tests {
     }
 
     #[rstest]
+    #[case("-1", "-1")]
+    fn test_should_evaluate_signed_number(#[case] expr: &str, #[case] result: &str) {
+        assert_eq!(evaluate(expr), Ok(result.into()));
+    }
+
+    #[rstest]
     #[case("123", "123")]
     #[case("18+1.48", "19.48")]
     #[case(" 1+\t2+    3+4 ", "10")]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -16,8 +16,6 @@ pub enum Error {
     /// such expressions.
     #[error("empty expression")]
     EmptyExpression(),
-    #[error("number expression {0} has an invalid format: {1}")]
-    InvalidNumberExpr(String, String),
     /// Indicates that an expression is invalid.
     /// This error variant contains a field indicating from which position the expression
     /// becomes invalid.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -46,7 +46,6 @@ mod tests {
 
     #[rstest]
     #[case("invalid")]
-    #[case("+1")]
     #[case("1+")]
     #[case("1++1")]
     fn test_should_fail_when_expression_is_invalid(#[case] expr: &str) {
@@ -55,6 +54,7 @@ mod tests {
 
     #[rstest]
     #[case("-1", "-1")]
+    #[case("+1", "1")]
     fn test_should_evaluate_signed_number(#[case] expr: &str, #[case] result: &str) {
         assert_eq!(evaluate(expr), Ok(result.into()));
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -47,7 +47,8 @@ mod tests {
     #[rstest]
     #[case("invalid")]
     #[case("1+")]
-    #[case("1++1")]
+    #[case("1+*1")]
+    #[case("1**1")]
     fn test_should_fail_when_expression_is_invalid(#[case] expr: &str) {
         assert!(matches!(evaluate(expr), Err(Error::InvalidExpression(_))));
     }
@@ -60,14 +61,28 @@ mod tests {
     }
 
     #[rstest]
+    #[case("1+-2", "-1")]
+    #[case("1++1", "2")]
+    #[case("1×-2", "-2")]
+    #[case("1---2", "-1")]
+    #[case("1----2", "3")]
+    fn test_should_evaluate_consecutive_negative_and_positive_signs(
+        #[case] expr: &str,
+        #[case] result: &str,
+    ) {
+        assert_eq!(evaluate(expr), Ok(result.into()));
+    }
+
+    #[rstest]
     #[case("123", "123")]
     #[case("18+1.48", "19.48")]
     #[case(" 1+\t2+    3+4 ", "10")]
     #[case("1+2-4", "-1")]
-    #[case("1+2×4", "9")]
+    #[case("1+2×4.5", "10")]
     #[case("13×24-54-52-45×37×90+63", "-149581")]
     #[case("91×59×41×88×21+69+67×8", "406798997")]
-    fn test_should_evaluate_valid_expressions(#[case] num_repr: &str, #[case] result: &str) {
-        assert_eq!(evaluate(num_repr), Ok(result.into()));
+    #[case("1+2×-3", "-5")]
+    fn test_should_evaluate_valid_expressions(#[case] expr: &str, #[case] result: &str) {
+        assert_eq!(evaluate(expr), Ok(result.into()));
     }
 }

--- a/src/engine/number.rs
+++ b/src/engine/number.rs
@@ -1,8 +1,5 @@
 use std::fmt::Display;
-use std::num::ParseFloatError;
 use std::ops::{Add, Mul, Neg, Sub};
-
-use crate::engine::Error;
 
 /// A wrapper around a decimal number.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -11,10 +8,8 @@ pub struct Number {
 }
 
 impl Number {
-    pub fn from_str(decimal_repr: &str) -> Result<Self, Error> {
-        let value = decimal_repr.parse().map_err(|pre: ParseFloatError| {
-            Error::InvalidNumberExpr(decimal_repr.to_string(), pre.to_string())
-        })?;
+    pub fn from_str(decimal_repr: &str) -> Result<Self, ()> {
+        let value = decimal_repr.parse().map_err(|_| ())?;
         Ok(Number { value })
     }
 }

--- a/src/engine/number.rs
+++ b/src/engine/number.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 use std::num::ParseFloatError;
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Mul, Neg, Sub};
 
 use crate::engine::Error;
 
@@ -55,6 +55,14 @@ impl Mul for Number {
     }
 }
 
+impl Neg for Number {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Number { value: -self.value }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::engine::number::Number;
@@ -84,5 +92,11 @@ mod tests {
         let lhs = Number::from_str("3.5").unwrap();
         let rhs = Number::from_str("3").unwrap();
         assert_eq!("10.5", (lhs * rhs).to_string());
+    }
+
+    #[test]
+    fn test_negate_number() {
+        let num = Number::from_str("3.5").unwrap();
+        assert_eq!("-3.5", (-num).to_string());
     }
 }

--- a/src/engine/number.rs
+++ b/src/engine/number.rs
@@ -1,8 +1,8 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display, Formatter};
 use std::ops::{Add, Mul, Neg, Sub};
 
 /// A wrapper around a decimal number.
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Copy, Clone, Default, PartialEq)]
 pub struct Number {
     value: f64,
 }
@@ -18,8 +18,14 @@ impl Number {
     }
 }
 
+impl Debug for Number {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
 impl Display for Number {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.value)
     }
 }

--- a/src/engine/number.rs
+++ b/src/engine/number.rs
@@ -8,6 +8,10 @@ pub struct Number {
 }
 
 impl Number {
+    pub fn zero() -> Self {
+        Number { value: 0. }
+    }
+
     pub fn from_str(decimal_repr: &str) -> Result<Self, ()> {
         let value = decimal_repr.parse().map_err(|_| ())?;
         Ok(Number { value })

--- a/src/engine/operator.rs
+++ b/src/engine/operator.rs
@@ -1,3 +1,4 @@
+/// Describes an operation to perform on values.
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
 pub enum OperatorType {
     Addition,

--- a/src/engine/operator.rs
+++ b/src/engine/operator.rs
@@ -5,3 +5,27 @@ pub enum OperatorType {
     Subtraction,
     Multiplication,
 }
+
+/// Describes either a positive `+` or negative `-` sign which can be present in front of
+/// an expression.
+pub enum Sign {
+    Positive,
+    Negative,
+}
+
+impl Sign {
+    pub fn from_operator(op_type: OperatorType) -> Result<Self, ()> {
+        match op_type {
+            OperatorType::Addition => Ok(Self::Positive),
+            OperatorType::Subtraction => Ok(Self::Negative),
+            _ => Err(()),
+        }
+    }
+
+    pub fn is_negative(&self) -> bool {
+        match &self {
+            Sign::Positive => false,
+            Sign::Negative => true,
+        }
+    }
+}

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -120,8 +120,10 @@ fn prioritize_operators(naive_tree: Ast) -> Ast {
                         Ast::Operator(kind, Box::new(old_child), rhs)
                     }
                 }
+                Ast::Negative(_) => unimplemented!(),
             }
         }
+        Ast::Negative(_) => unimplemented!(),
     }
 }
 

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -211,6 +211,7 @@ pub mod test_helpers {
 
     const ADD_CHAR: &'static str = "+";
     const SUB_CHAR: &'static str = "-";
+    const MUL_CHAR: &'static str = "×";
 
     pub fn invalid_token(content: &str) -> Token {
         Token::new(TokenType::Invalid, content)
@@ -230,5 +231,9 @@ pub mod test_helpers {
 
     pub fn sub_token() -> Token<'static> {
         Token::new(TokenType::Operator(OperatorType::Subtraction), SUB_CHAR)
+    }
+
+    pub fn mul_token() -> Token<'static> {
+        Token::new(TokenType::Operator(OperatorType::Multiplication), MUL_CHAR)
     }
 }

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -210,6 +210,7 @@ pub mod test_helpers {
     use crate::engine::token::{Token, TokenType};
 
     const ADD_CHAR: &'static str = "+";
+    const SUB_CHAR: &'static str = "-";
 
     pub fn invalid_token(content: &str) -> Token {
         Token::new(TokenType::Invalid, content)
@@ -225,5 +226,9 @@ pub mod test_helpers {
 
     pub fn add_token() -> Token<'static> {
         Token::new(TokenType::Operator(OperatorType::Addition), ADD_CHAR)
+    }
+
+    pub fn sub_token() -> Token<'static> {
+        Token::new(TokenType::Operator(OperatorType::Subtraction), SUB_CHAR)
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -56,13 +56,6 @@ impl LatorApp {
                 self.results_panel
                     .add_result(Result::Error("invalid expression".into()));
             }
-            Err(unexpected) => {
-                eprintln!("Unexpected expression evaluation error: {:?}", unexpected);
-                self.input_panel
-                    .add_history(HistorizedExpression::Invalid(expr, 0));
-                self.results_panel
-                    .add_result(Result::Error("unexpected error".into()));
-            }
         }
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -3,7 +3,7 @@ use eframe::epaint::{Color32, FontFamily, FontId, Margin};
 /// The background color of the input panel.
 pub const INPUT_BG_COLOR: Color32 = Color32::WHITE;
 /// The background color of the results panel.
-pub const RESULTS_BG_COLOR: Color32 = Color32::from_rgb(208, 208, 208);
+pub const RESULTS_BG_COLOR: Color32 = Color32::from_rgb(238, 238, 238);
 
 /// The font color of the current expression.
 pub const INPUT_TEXT_COLOR: Color32 = Color32::from_rgb(34, 34, 34);
@@ -12,7 +12,7 @@ pub const PREVIOUS_TEXT_COLOR: Color32 = Color32::from_rgb(68, 68, 68);
 /// The font color of error messages and invalid tokens in previously submitted expressions.
 pub const ERROR_TEXT_COLOR: Color32 = Color32::from_rgb(185, 48, 42);
 /// The font color of the results.
-pub const RESULTS_TEXT_COLOR: Color32 = Color32::from_rgb(100, 100, 100);
+pub const RESULTS_TEXT_COLOR: Color32 = Color32::from_rgb(70, 70, 70);
 /// The font color of a selected expression or result.
 pub const TEXT_SELECTION_COLOR: Color32 = Color32::from_rgb(34, 34, 34);
 


### PR DESCRIPTION
# Context

Currently, starting an operation with a positive `+` or negative `-` sign yields an `invalid expression` error.

Operations with signed numbers are also not supported. For example, the following expressions would be considered invalid:

- `1×-2`
- `1+-2`

# Changes

An operator `-` or `+` is treated as a sign in two cases:

- When it appears at the beginning of an expression (ignoring white spaces).
- When it follows another operator.

These signs are applied to the next sequence of tokens which can be parsed as a valid AST.

- Positive signs (`+`) have no effect and are ignored.
- Negative signs (`-`) invert the value of the expression to which they apply.

When parsing a sequence of consecutive signs, the sequence is simplified according to the following rules:

- A sequence with an odd number of negative signs is reduced to a single negative sign.
- A sequence with an even number of negative signs is reduced to no sign.