### PR TITLE
Improve invalid expression highlighting

### DIFF
--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -11,7 +11,7 @@ use crate::engine::operator::OperatorType;
 ///     /   \
 ///    2     3
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Ast {
     /// An actual, raw number.
     /// Leaf nodes in AST are always [Ast::Number] nodes.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -57,7 +57,7 @@ mod tests {
     #[case("-1", "-1")]
     #[case("+1", "1")]
     fn test_should_evaluate_signed_number(#[case] expr: &str, #[case] result: &str) {
-        assert_eq!(evaluate(expr), Ok(result.into()));
+        assert_eq!(evaluate(expr), Ok(result.to_string()));
     }
 
     #[rstest]
@@ -70,7 +70,7 @@ mod tests {
         #[case] expr: &str,
         #[case] result: &str,
     ) {
-        assert_eq!(evaluate(expr), Ok(result.into()));
+        assert_eq!(evaluate(expr), Ok(result.to_string()));
     }
 
     #[rstest]
@@ -83,6 +83,6 @@ mod tests {
     #[case("91×59×41×88×21+69+67×8", "406798997")]
     #[case("1+2×-3", "-5")]
     fn test_should_evaluate_valid_expressions(#[case] expr: &str, #[case] result: &str) {
-        assert_eq!(evaluate(expr), Ok(result.into()));
+        assert_eq!(evaluate(expr), Ok(result.to_string()));
     }
 }

--- a/src/engine/number.rs
+++ b/src/engine/number.rs
@@ -104,4 +104,10 @@ mod tests {
         let num = Number::from_str("3.5").unwrap();
         assert_eq!("-3.5", (-num).to_string());
     }
+
+    #[test]
+    fn test_decimal_number_with_no_decimal_part() {
+        let num = Number::from_str("12.").unwrap();
+        assert_eq!("12", num.to_string())
+    }
 }

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -46,6 +46,16 @@ impl<'a> Token<'a> {
     }
 }
 
+impl<'a> Token<'a> {
+    pub fn is_whitespace(&self) -> bool {
+        self.token_type == TokenType::Whitespace
+    }
+
+    pub fn is_operator(&self) -> bool {
+        matches!(self.token_type, TokenType::Operator(_))
+    }
+}
+
 /** Split the expression in an ordered sequence of tokens.\
 Each character of the expression belongs to exactly one of the returned tokens.
 */


### PR DESCRIPTION
# Context

When an expression contains an incomplete operation, the engine indicates that the error is located at the last token.

This might not always be valid. For example, the expression might end by a sign or a white space token.

# Changes

- When an operation is incomplete, indicate that the error is located at the last operator.

Additionally, this PR adds the following minor improvements:

- Clarify assertions in some unit tests.
- Implement an `unimplemented!()` branch when prioritizing an AST.
- Add a unit test to make sure that numbers ending with a decimal separator (`.`) are correctly parsed.