### PR TITLE
Generalize prioritization

### DIFF
--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 use crate::engine::number::Number;
 use crate::engine::operator::OperatorType;
 
@@ -29,6 +31,16 @@ impl Ast {
             Ast::Number(num) => *num,
             Ast::Operator(op, lhs, rhs) => op.calculate(lhs.resolve(), rhs.resolve()),
             Ast::Negative(value) => -value.resolve(),
+        }
+    }
+}
+
+impl Display for Ast {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Ast::Number(value) => write!(f, "{}", value),
+            Ast::Operator(op_type, lhs, rhs) => write!(f, "{}{}{}", lhs, op_type, rhs),
+            Ast::Negative(value) => write!(f, "-{}", value),
         }
     }
 }

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -26,9 +26,9 @@ pub enum Ast {
 
 impl Ast {
     /// Resolve the value from an AST, starting from the bottom nodes up to the root of the tree.
-    pub fn resolve(&self) -> Number {
+    pub fn resolve(self) -> Number {
         match self {
-            Ast::Number(num) => *num,
+            Ast::Number(num) => num,
             Ast::Operator(op, lhs, rhs) => op.calculate(lhs.resolve(), rhs.resolve()),
             Ast::Negative(value) => -value.resolve(),
         }

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -7,7 +7,7 @@ use crate::engine::operator::OperatorType;
 /// ```text
 ///    +
 ///  /   \
-/// 1     *
+/// 1     ×
 ///     /   \
 ///    2     3
 /// ```
@@ -23,6 +23,7 @@ pub enum Ast {
 }
 
 impl Ast {
+    /// Resolve the value from an AST, starting from the bottom nodes up to the root of the tree.
     pub fn resolve(&self) -> Number {
         match self {
             Ast::Number(num) => *num,
@@ -38,16 +39,6 @@ impl OperatorType {
             OperatorType::Addition => lhs + rhs,
             OperatorType::Subtraction => lhs - rhs,
             OperatorType::Multiplication => lhs * rhs,
-        }
-    }
-
-    /// Indicates the priority of an operator.\
-    /// A higher value means a higher priority.
-    pub fn priority(&self) -> usize {
-        match self {
-            OperatorType::Addition => 0,
-            OperatorType::Subtraction => 0,
-            OperatorType::Multiplication => 1,
         }
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -23,7 +23,7 @@ pub enum Error {
     InvalidExpression(usize),
 }
 
-/** Evaluates textual expressions */
+/// Evaluates textual expressions
 pub fn evaluate(expr: &str) -> Result<String, Error> {
     let tokens = tokenize(expr);
     let ast_root = parse(&tokens)?;
@@ -47,8 +47,8 @@ mod tests {
     #[rstest]
     #[case("invalid")]
     #[case("1+")]
-    #[case("1+*1")]
-    #[case("1**1")]
+    #[case("1+×1")]
+    #[case("1××1")]
     fn test_should_fail_when_expression_is_invalid(#[case] expr: &str) {
         assert!(matches!(evaluate(expr), Err(Error::InvalidExpression(_))));
     }

--- a/src/engine/operator.rs
+++ b/src/engine/operator.rs
@@ -6,6 +6,18 @@ pub enum OperatorType {
     Multiplication,
 }
 
+impl OperatorType {
+    /// Indicates the priority of an operator. A higher value means a higher priority.\
+    /// Higher priority operators should be evaluated first.
+    pub fn priority(&self) -> usize {
+        match self {
+            OperatorType::Addition => 0,
+            OperatorType::Subtraction => 0,
+            OperatorType::Multiplication => 1,
+        }
+    }
+}
+
 /// Describes either a positive `+` or negative `-` sign which can be present in front of
 /// an expression.
 pub enum Sign {

--- a/src/engine/operator.rs
+++ b/src/engine/operator.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Write};
+
 /// Describes an operation to perform on values.
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
 pub enum OperatorType {
@@ -15,6 +17,18 @@ impl OperatorType {
             OperatorType::Subtraction => 0,
             OperatorType::Multiplication => 1,
         }
+    }
+}
+
+impl Display for OperatorType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let repr = match self {
+            OperatorType::Addition => '+',
+            OperatorType::Subtraction => '-',
+            OperatorType::Multiplication => '×',
+        };
+
+        f.write_char(repr)
     }
 }
 

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -123,22 +123,22 @@ impl ParsingContext {
 /// Given a sequence of tokens, retrieve the position of the last unfinished operator, ignoring
 /// following sign operators.
 fn find_position_of_unfinished_operator(tokens: &[Token]) -> usize {
-    let mut current_pos = 0;
-    let mut last_operator_pos = 0;
-    let mut in_operator_sequence = false;
+    let mut current_position = 0;
+    let mut last_operator_position = 0;
+    let mut previous_token_was_operator = false;
 
     for token in tokens {
-        if !in_operator_sequence && token.is_operator() {
-            last_operator_pos = current_pos;
+        if !previous_token_was_operator && token.is_operator() {
+            last_operator_position = current_position;
         }
 
         if !token.is_whitespace() {
-            in_operator_sequence = token.is_operator();
+            previous_token_was_operator = token.is_operator();
         }
 
-        current_pos += token.length();
+        current_position += token.length();
     }
-    return last_operator_pos;
+    return last_operator_position;
 }
 
 /// Re-arrange a naive AST to make sure that operators with higher priority are evaluated first.\

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -56,9 +56,8 @@ impl<'a> Token<'a> {
     }
 }
 
-/** Split the expression in an ordered sequence of tokens.\
-Each character of the expression belongs to exactly one of the returned tokens.
-*/
+/// Split the expression in an ordered sequence of tokens.\
+/// Each character of the expression belongs to exactly one of the returned tokens.
 pub fn tokenize(expression: &str) -> Vec<Token> {
     let mut tokens = vec![];
     let mut cursor = 0;
@@ -140,10 +139,11 @@ fn build_token_matching_pattern<'a>(
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use crate::engine::token::test_helpers::{
         add_token, invalid_token, num_token, whitespace_token,
     };
-    use rstest::rstest;
 
     use super::*;
 


### PR DESCRIPTION
# Context

The prioritization algorithm restructures an AST to make sure that operators with higher priorities (e.g. the multiplication operator) are evaluated before operators with lower priorities (e.g. the addition operator).

The current algorithm requires the input AST to be developed only through the left branch. This means that it expects the right branch of all nodes to be either a `Number` node or a `Negative` node.

This assumption could limit future changes to the AST parsing algorithm and could introduce bugs if this algorithm were to change in the future.

# Changes

- The prioritization algorithm now supports any tree as an input. (2a8a333cc06c9466fa6427d01da157a5b7bda515, b07204cec954d57551db7bfdb8e93bc7f350819a)
- The Ast::resolve() method now consumes the AST. (07ad517318603be5678ef255f476df2b791302f9)
- Minor refactoring and comment changes. (9d33db96b39cbbec741bc92b92c0ac07cb0ce017)