### PR TITLE
Support parenthesis

### DIFF
--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -65,7 +65,7 @@ impl OperatorType {
 mod tests {
     use rstest::rstest;
 
-    use crate::engine::ast::test_helpers::{add_node, neg_node, num_node, prioritized_node};
+    use crate::engine::ast::test_helpers::{add_node, neg_node, num_node, parenthesized_node};
 
     #[rstest]
     #[case("0")]
@@ -96,7 +96,7 @@ mod tests {
 
     #[test]
     fn should_return_original_value_when_prioritized() {
-        let ast = prioritized_node(num_node("10"));
+        let ast = parenthesized_node(num_node("10"));
         assert_eq!(ast.resolve().to_string(), "10")
     }
 }
@@ -128,7 +128,7 @@ pub mod test_helpers {
         Ast::Negative(Box::new(value))
     }
 
-    pub fn prioritized_node(value: Ast) -> Ast {
+    pub fn parenthesized_node(value: Ast) -> Ast {
         Ast::Parenthesized(Box::new(value))
     }
 }

--- a/src/engine/ast.rs
+++ b/src/engine/ast.rs
@@ -124,10 +124,6 @@ pub mod test_helpers {
         Ast::Operator(OperatorType::Addition, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn sub_node(lhs: Ast, rhs: Ast) -> Ast {
-        Ast::Operator(OperatorType::Subtraction, Box::new(lhs), Box::new(rhs))
-    }
-
     pub fn neg_node(value: Ast) -> Ast {
         Ast::Negative(Box::new(value))
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -84,7 +84,8 @@ mod tests {
     #[case("91×59×41×88×21+69+67×8", "406798997")]
     #[case("1+2×-3", "-5")]
     #[case("42×59×70-+-+14÷78-24÷25×-+79", "173536.0194871795")]
+    #[case("35+28+( -(-(+43.7++88×66+2-+-56)))", "5972.7")]
     fn test_should_evaluate_valid_expressions(#[case] expr: &str, #[case] result: &str) {
-        assert_eq!(evaluate(expr), Ok(result.to_string()));
+        assert_eq!(evaluate(expr), Ok(result.to_string()), "{expr}");
     }
 }

--- a/src/engine/number.rs
+++ b/src/engine/number.rs
@@ -8,10 +8,6 @@ pub struct Number {
 }
 
 impl Number {
-    pub fn zero() -> Self {
-        Number { value: 0. }
-    }
-
     pub fn from_str(decimal_repr: &str) -> Result<Self, ()> {
         let value = decimal_repr.parse().map_err(|_| ())?;
         Ok(Number { value })

--- a/src/engine/operator.rs
+++ b/src/engine/operator.rs
@@ -55,6 +55,7 @@ impl Sign {
         }
     }
 
+    /// Compute the value of a sign after combining two signs together.
     pub fn combine(self, other: Sign) -> Self {
         if self == other {
             Self::Positive

--- a/src/engine/operator.rs
+++ b/src/engine/operator.rs
@@ -40,6 +40,7 @@ impl Display for OperatorType {
 
 /// Describes either a positive `+` or negative `-` sign which can be present in front of
 /// an expression.
+#[derive(Eq, PartialEq)]
 pub enum Sign {
     Positive,
     Negative,
@@ -54,10 +55,11 @@ impl Sign {
         }
     }
 
-    pub fn is_negative(&self) -> bool {
-        match &self {
-            Sign::Positive => false,
-            Sign::Negative => true,
+    pub fn combine(self, other: Sign) -> Self {
+        if self == other {
+            Self::Positive
+        } else {
+            Self::Negative
         }
     }
 }

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -86,6 +86,10 @@ impl NestedStates {
     }
 
     fn close_parenthesis(&mut self) -> Result<(), ()> {
+        if self.states.len() <= 1 {
+            return Err(());
+        }
+
         let closed_sub_expr_state = self.states.pop().unwrap().value;
         let ast = closed_sub_expr_state.into_value()?;
         let parenthesized = Ast::Parenthesized(Box::new(ast));
@@ -437,6 +441,7 @@ mod tests {
         num_token("1"), add_token(), open_par_token(), num_token("1")],
         Error::InvalidExpression(2))
     ]
+    #[case(&[num_token("1"), close_par_token()], Error::InvalidExpression(1))]
     fn test_parsing_expression_should_fail_when_parentheses_do_not_match(
         #[case] seq: &[Token],
         #[case] err: Error,

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -75,6 +75,8 @@ impl ParsingContext {
             TokenType::Whitespace => Ok(self), // Whitespaces do not affect the parsing context.
             TokenType::Number => self.update_from_number(token.content()),
             TokenType::Operator(op_type) => self.update_from_operator(op_type),
+            TokenType::OpenParenthesis => Err(()),
+            TokenType::CloseParenthesis => Err(()),
         }
     }
 

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -448,6 +448,23 @@ mod tests {
     ) {
         assert_eq!(Err(err), parse(&seq), "{:?}", seq);
     }
+
+    #[test]
+    fn test_parsing_expression_should_fail_when_parenthesis_closes_on_pending_operation() {
+        let seq = [
+            open_par_token(),
+            num_token("1"),
+            add_token(),
+            close_par_token(),
+        ];
+        assert_eq!(Err(Error::InvalidExpression(3)), parse(&seq), "{:?}", seq);
+    }
+
+    #[test]
+    fn test_parsing_expression_should_fail_when_parentheses_englobe_nothing() {
+        let seq = [open_par_token(), close_par_token()];
+        assert_eq!(Err(Error::InvalidExpression(1)), parse(&seq), "{:?}", seq);
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -534,7 +534,6 @@ mod test_prioritization {
 
     #[test]
     fn should_prioritize_negative_parenthesized_sub_tree() {
-        // A tree naively parsed as ((1+2)*3)+4 should be updated to 1+(2*3)+4
         let tree_to_prioritize = mul_node(
             add_node(num_node("1"), num_node("2")),
             add_node(num_node("3"), num_node("4")),
@@ -549,7 +548,6 @@ mod test_prioritization {
 
     #[test]
     fn should_not_swap_parenthesized_operator_with_parent() {
-        // A tree naively parsed as ((1+2)*3)+4 should be updated to 1+(2*3)+4
         let ast = mul_node(
             parenthesized_node(add_node(num_node("1"), num_node("2"))),
             num_node("5"),

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -249,4 +249,9 @@ pub mod test_helpers {
         let operator_type = OperatorType::Multiplication;
         Token::new(TokenType::Operator(operator_type), operator_type.as_str())
     }
+
+    pub fn div_token() -> Token<'static> {
+        let operator_type = OperatorType::Division;
+        Token::new(TokenType::Operator(operator_type), operator_type.as_str())
+    }
 }

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -15,6 +15,10 @@ pub enum TokenType {
     Number,
     /// Classifies a token as an operator sign.
     Operator(OperatorType),
+    /// Indicates the start of a prioritized sub-expression.
+    OpenParenthesis,
+    /// Indicates the end of a prioritized sub-expression.
+    CloseParenthesis,
 }
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
@@ -79,6 +83,8 @@ lazy_static! {
         (TokenType::Operator(OperatorType::Subtraction), "-"),
         (TokenType::Operator(OperatorType::Multiplication), "×"),
         (TokenType::Operator(OperatorType::Division), "÷"),
+        (TokenType::OpenParenthesis, r"\("),
+        (TokenType::CloseParenthesis, r"\)"),
     ])
     .into_iter()
     .map(|(token_type, re_expr)| (token_type, Regex::new(re_expr).unwrap()))
@@ -176,6 +182,13 @@ mod tests {
     }
 
     #[rstest]
+    #[case("(", TokenType::OpenParenthesis)]
+    #[case(")", TokenType::CloseParenthesis)]
+    fn should_evaluate_parenthesis_token(#[case] expr: &str, #[case] token_type: TokenType) {
+        assert_eq!(vec![str_to_token(expr, token_type)], tokenize(expr));
+    }
+
+    #[rstest]
     #[case("123abc", vec![num_token("123"), invalid_token("abc")])]
     #[case("abc123", vec![invalid_token("abc"), num_token("123")])]
     #[case("123+.456", vec![num_token("123"), add_token(), num_token(".456")])]
@@ -186,6 +199,7 @@ mod tests {
     #[test]
     fn should_extract_whitespace_tokens() {
         let expr = " 1   + \t\t\t   \x0a2 ";
+
         let expected_sequence = vec![
             whitespace_token(" "),
             num_token("1"),
@@ -195,6 +209,7 @@ mod tests {
             num_token("2"),
             whitespace_token(" "),
         ];
+
         assert_eq!(expected_sequence, tokenize(expr));
     }
 

--- a/src/engine/token.rs
+++ b/src/engine/token.rs
@@ -254,4 +254,12 @@ pub mod test_helpers {
         let operator_type = OperatorType::Division;
         Token::new(TokenType::Operator(operator_type), operator_type.as_str())
     }
+
+    pub fn open_par_token() -> Token<'static> {
+        Token::new(TokenType::OpenParenthesis, "(")
+    }
+
+    pub fn close_par_token() -> Token<'static> {
+        Token::new(TokenType::CloseParenthesis, ")")
+    }
 }


### PR DESCRIPTION
# Context

Parenthesis tokens can be used to prioritize a part of an expression, regardless of the priority of operators.

# Changes

- Support parenthesis in expressions